### PR TITLE
Update to work with jsdom v10+

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,14 @@ function assign(target) {
 
 class NodeDebugEnvironment {
     constructor(config) {
-        const doc = require('jsdom').jsdom(undefined, {
+        // jsdom v10+ has new api, but retains support for old api
+        try {
+          var jsdom = require('jsdom/lib/old-api.js')
+        } catch (e) {
+          var jsdom = require('jsdom')
+        }
+
+       const doc = jsdom.jsdom(undefined, {
             url: config.testURL
         });
 


### PR DESCRIPTION
jsdom v10 introduced a new api, incompatible with previous versions.

This caused "TypeError: require(...).jsdom is not a function" when
jest-environment-jsdom-debug was used with jsdom v10 or later.

As new versions of jsdom still support the old api for now, fix by
requiring the "old api", which is available on the new versions, and
fall back to the previous code otherwise.

Note use of var to get around block scoping of const with try/catch.
I'm not a javascript developer, I just need to do some quick and dirty
work on a js project and I want a debugger. My code probably sucks,
please, please feel free to change to something more appropriate.